### PR TITLE
fix CORS in dev

### DIFF
--- a/src/pages/cost-calculator/index.jsx
+++ b/src/pages/cost-calculator/index.jsx
@@ -60,14 +60,11 @@ export function CostCalculatorPage() {
 
     if (token) {
       try {
-        const response = await axios.get(
-          `${creds.gatewayUrl}/v1/cost-calculator/countries`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
+        const response = await axios.get(`/api/v1/cost-calculator/countries`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
         setCountries(response.data.data);
       } catch (error) {
         console.error("Error fetching countries:", error);
@@ -149,7 +146,7 @@ export function CostCalculatorPage() {
 
     try {
       const response = await axios.post(
-        `${creds.gatewayUrl}/v1/cost-calculator/estimation`,
+        `/api/v1/cost-calculator/estimation`,
         payload,
         {
           headers: {

--- a/src/pages/create-company/index.jsx
+++ b/src/pages/create-company/index.jsx
@@ -53,7 +53,7 @@ export function CompanyCreationPage() {
 
       if (token) {
         try {
-          const response = await axios.get(`${creds.gatewayUrl}${endpoint}`, {
+          const response = await axios.get(endpoint, {
             headers: {
               Authorization: `Bearer ${token}`,
             },
@@ -71,13 +71,13 @@ export function CompanyCreationPage() {
         }
       }
     },
-    [creds.gatewayUrl, fetchAccessToken]
+    [fetchAccessToken]
   );
 
   useEffect(() => {
     if (initialFormValues && !isAddressDetails) {
       fetchSchema(
-        `/v1/companies/schema?country_code=${initialFormValues.country_code}&form=address_details`
+        `/api/v1/companies/schema?country_code=${initialFormValues.country_code}&form=address_details`
       );
     }
   }, [fetchSchema, isAddressDetails, initialFormValues]);
@@ -111,7 +111,7 @@ export function CompanyCreationPage() {
       };
 
       const postResponse = await axios.post(
-        `${creds.gatewayUrl}/v1/companies${actionParam}`,
+        `/api/v1/companies${actionParam}`,
         payload,
         {
           headers: {

--- a/src/pages/create-employment/index.jsx
+++ b/src/pages/create-employment/index.jsx
@@ -44,7 +44,7 @@ export function EmploymentCreationPage() {
 
       if (token) {
         try {
-          const response = await axios.get(`${creds.gatewayUrl}${endpoint}`, {
+          const response = await axios.get(endpoint, {
             headers: {
               Authorization: `Bearer ${token}`,
             },
@@ -62,13 +62,13 @@ export function EmploymentCreationPage() {
         }
       }
     },
-    [creds.gatewayUrl, fetchAccessToken]
+    [fetchAccessToken]
   );
 
   useEffect(() => {
     if (initialFormValues && !isContractDetails) {
       fetchSchema(
-        `/v1/countries/${initialFormValues.country_code}/employment_basic_information`
+        `/api/v1/countries/${initialFormValues.country_code}/employment_basic_information`
       );
     }
   }, [fetchSchema, isContractDetails, initialFormValues]);
@@ -76,7 +76,7 @@ export function EmploymentCreationPage() {
   useEffect(() => {
     if (employmentId && isContractDetails) {
       fetchSchema(
-        `/v1/countries/${initialFormValues.country_code}/contract_details`
+        `/api/v1/countries/${initialFormValues.country_code}/contract_details`
       );
     }
   }, [employmentId, isContractDetails, fetchSchema, initialFormValues]);
@@ -95,7 +95,7 @@ export function EmploymentCreationPage() {
         };
 
         const postResponse = await axios.post(
-          `${creds.gatewayUrl}/v1/employments`,
+          `/api/v1/employments`,
           {
             basic_information: basicInformation, // Pass the dynamically built basic information
             country_code: initialFormValues.country_code,
@@ -116,7 +116,7 @@ export function EmploymentCreationPage() {
         }
       } else {
         const patchResponse = await axios.patch(
-          `${creds.gatewayUrl}/v1/employments/${employmentId}`,
+          `/api/v1/employments/${employmentId}`,
           {
             contract_details: {
               ...jsonValues,
@@ -137,7 +137,7 @@ export function EmploymentCreationPage() {
           if (initialFormValues.send_self_enrollment_invitation) {
             try {
               const inviteResponse = await axios.post(
-                `${creds.gatewayUrl}/v1/employments/${employmentId}/invite`,
+                `/api/v1/employments/${employmentId}/invite`,
                 {},
                 {
                   headers: {

--- a/src/utils/auth-utils.js
+++ b/src/utils/auth-utils.js
@@ -59,7 +59,7 @@ export const getClientCredentialsToken = async (
   const encodedCredentials = btoa(`${clientId}:${clientSecret}`);
   try {
     const response = await axios.post(
-      `${gatewayUrl}/auth/oauth2/token`,
+      `/api/auth/oauth2/token`,
       new URLSearchParams({
         grant_type: "client_credentials",
       }),
@@ -70,7 +70,6 @@ export const getClientCredentialsToken = async (
         },
       }
     );
-
     return response.data.access_token;
   } catch (error) {
     const errorMessage = `Error fetching form data: Error fetching access token: ${error.message}`;

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,4 +10,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "https://gateway.niceremote.com",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
 });


### PR DESCRIPTION
HTTP requests made directly from the browser to the Remote API cause a CORS error. We've been using a Chrome extension to bypass this issue but Vite offers a proxy configuration that provides a more robust solution.

**What does this solution means?**

This fixes CORS in dev mode.

From now on every request made from the browser to Remote API, needs to start with `/api`. 

**Before**: `https://gateway.niceremote.com/v1/cost-calculator/countries`
**Now**: `/api/v1/cost-calculator/countries`