### PR TITLE
Allow to create an employment on company's behalf

### DIFF
--- a/src/components/ui/form/DynamicForm.jsx
+++ b/src/components/ui/form/DynamicForm.jsx
@@ -1,10 +1,9 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useFormik } from "formik";
 import PropTypes from "prop-types";
 import { Button } from "@/components/ui/Button.jsx";
 
 const DynamicForm = ({ fields, validationSchema, onSubmit }) => {
-  const [buttonLabel, setButtonLabel] = useState("Submit");
   const initialValues = useMemo(() => {
     return fields.reduce((acc, field) => {
       acc[field.name] = field.defaultValue || "";
@@ -35,7 +34,7 @@ const DynamicForm = ({ fields, validationSchema, onSubmit }) => {
         }
         return acc;
       }, {});
-      setButtonLabel("Submitting...");
+
       onSubmit(castedValues);
     },
   });
@@ -97,7 +96,7 @@ const DynamicForm = ({ fields, validationSchema, onSubmit }) => {
           </div>
         ))}
         <Button type="submit" variant="default">
-          {buttonLabel}
+          Submit
         </Button>
       </form>
     </div>

--- a/src/components/ui/form/Fields.jsx
+++ b/src/components/ui/form/Fields.jsx
@@ -80,7 +80,7 @@ function FieldCheckbox({ type, name, label, description, meta }) {
   return (
     <div key={name}>
       <div className="flex">
-        <FormikField type={type} name={name} id={name} className="mb-1 mr-1" />
+        <FormikField type={type} name={name} id={name} />
         <label className="label" htmlFor={name}>
           {label}
         </label>

--- a/src/components/ui/form/Form.jsx
+++ b/src/components/ui/form/Form.jsx
@@ -106,7 +106,6 @@ function formValuesToJsonValues(values, fields) {
 }
 
 export default function Form({ jsonSchema, onSubmit, className }) {
-  const [buttonLabel, setButtonLabel] = useState("Submit");
   const [modifiedSchema, setModifiedSchema] = useState(null);
 
   useEffect(() => {
@@ -149,7 +148,6 @@ export default function Form({ jsonSchema, onSubmit, className }) {
     console.log("Form values before casting:", formValues);
     const jsonValues = formValuesToJsonValues(formValues, fields);
     console.log("Form values after casting:", jsonValues);
-    setButtonLabel("Submitting...");
     onSubmit(jsonValues);
   }
 
@@ -184,7 +182,7 @@ export default function Form({ jsonSchema, onSubmit, className }) {
               );
             })}
 
-            <Button type="submit">{buttonLabel}</Button>
+            <Button type="submit">Submit</Button>
           </FormikForm>
         </div>
       )}

--- a/src/domains/company/CreateCompany.jsx
+++ b/src/domains/company/CreateCompany.jsx
@@ -1,37 +1,25 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import Form from "@/components/ui/form/Form.jsx";
 import DynamicForm from "@/components/ui/form/DynamicForm.jsx";
 import { Result } from "@/components/Result.jsx";
 import { Loading } from "@/components/Loading.jsx";
 import { Button } from "@/components/ui/Button.jsx";
-import { fields, validationSchema } from "./fields.js";
-import { useCompany, useCompanyJsonSchema } from "./hooks.js";
-import { useCredentials } from "@/domains/shared/credentials/useCredentials.js";
+import { fields, validationSchema } from "./fields";
+import { useCompany, useCompanyJsonSchema } from "./hooks";
 
 export function CompanyCreation() {
   const [initialFormValues, setInitialFormValues] = useState();
-  const [localCustomerCredentials, setLocalCustomerCredentials] = useState();
-  const navigate = useNavigate();
-  const { updateCustomerCredentials } = useCredentials();
   const { data: jsonSchema, isLoading } = useCompanyJsonSchema(
     initialFormValues?.country_code
   );
-
   const {
     data: responseData,
-    mutate: createCompanyMutation,
+    mutate,
     error,
     isError,
     isPending,
-  } = useCompany({
-    onSuccess: ({ data }) => {
-      if (initialFormValues.get_oauth_access_tokens) {
-        setLocalCustomerCredentials(data.tokens);
-      }
-    },
-  });
+  } = useCompany();
 
   async function handleInitialFormSubmit(values) {
     setInitialFormValues(values);
@@ -58,7 +46,7 @@ export function CompanyCreation() {
       terms_of_service_accepted_at: new Date().toISOString(),
     };
 
-    createCompanyMutation({ queryParams: actionParam, bodyParams: payload });
+    mutate({ queryParams: actionParam, bodyParams: payload });
   }
 
   if (isLoading || isPending) {
@@ -81,24 +69,11 @@ export function CompanyCreation() {
         <>
           {responseData ? (
             <div className="result-area">
-              <Button
-                className=""
-                onClick={() => {
-                  if (localCustomerCredentials) {
-                    updateCustomerCredentials(localCustomerCredentials);
-                  }
-                  navigate("/create-employment");
-                }}
-              >
-                Create new employment
-              </Button>
-              {localCustomerCredentials && (
-                <p className="text-xs my-4">
-                  New employment will be created on behalf of{" "}
-                  <span className="font-bold">{initialFormValues.name}</span>
-                </p>
-              )}
+              <p className="result-message">Company created successfully ✓</p>
               <Result data={responseData} />
+              <Button onClick={() => window.location.reload()}>
+                Start Over
+              </Button>
             </div>
           ) : (
             <div className="flex flex-col items-center">

--- a/src/domains/company/hooks.js
+++ b/src/domains/company/hooks.js
@@ -34,9 +34,8 @@ export const useCompanyJsonSchema = (countryCode) => {
  * Estimates the cost of employment
  * @returns {import("@tanstack/react-query").UseMutationResult}
  */
-export const useCompany = (options) => {
+export const useCompany = () => {
   return useMutation({
     mutationFn: fetchCompany,
-    ...options,
   });
 };

--- a/src/domains/cost-calculator/CostCalculator.jsx
+++ b/src/domains/cost-calculator/CostCalculator.jsx
@@ -8,19 +8,8 @@ import { fields, validationSchema } from "./fields";
 
 export function CostCalculator() {
   const { credentials } = useCredentials();
-  const {
-    data: countries,
-    isLoading,
-    error: countriesError,
-    isError: isCountriesError,
-  } = useCountries();
-  const {
-    data: result,
-    mutate,
-    error: estimationError,
-    isError: isEstimationError,
-    isSuccess,
-  } = useEstimation();
+  const { data: countries, isLoading } = useCountries();
+  const { data: result, mutate, error, isError, isSuccess } = useEstimation();
 
   const handleSubmit = async (values) => {
     console.log("Form Submitted with values:", values);
@@ -85,20 +74,8 @@ export function CostCalculator() {
     );
   }
 
-  if (isEstimationError) {
-    return (
-      <p className="text-center error">
-        Error submitting estimation: {estimationError?.message}
-      </p>
-    );
-  }
-
-  if (isCountriesError) {
-    return (
-      <p className="text-center error">
-        Error fetching countries: {countriesError?.message}
-      </p>
-    );
+  if (isError) {
+    return <p className="text-center error">{error}</p>;
   }
 
   if (isLoading) {

--- a/src/domains/cost-calculator/hooks.js
+++ b/src/domains/cost-calculator/hooks.js
@@ -26,7 +26,6 @@ export const useCountries = () => {
     queryKey: ["countries"],
     queryFn: fetchCountries,
     select: (data) => data.data,
-    retry: false,
   });
 };
 

--- a/src/domains/employment/EmploymentCreation.jsx
+++ b/src/domains/employment/EmploymentCreation.jsx
@@ -20,7 +20,7 @@ export function EmploymentCreation() {
   // Fetches the JSON schema for the employment form
   const {
     data: jsonSchema,
-    isLoading: isLoadingSchema,
+    isLoading,
     isError,
     error,
   } = useJsonSchema(initialFormValues?.country_code, employmentId);
@@ -88,17 +88,17 @@ export function EmploymentCreation() {
     setSubmissionStatus(null);
   };
 
-  // if (isLoading) {
-  //   return <Loading />;
-  // }
+  if (isLoading) {
+    return <Loading />;
+  }
 
   if (isError) {
-    return <p className="error">Error fetching JSON Schema: {error.message}</p>;
+    return <p className="error">{error}</p>;
   }
 
   return (
     <>
-      {!initialFormValues || isLoadingSchema ? (
+      {!initialFormValues ? (
         <DynamicForm
           fields={fields}
           validationSchema={validationSchema}

--- a/src/domains/playground/JSONSchemaPlayground.jsx
+++ b/src/domains/playground/JSONSchemaPlayground.jsx
@@ -74,15 +74,7 @@ export function JSONSchemaPlayground() {
           <span className="font-bold">Disclaimer:</span> These are static JSON
           Schemas and may be outdated. This page is intended solely to help
           understand how forms are rendered based on JSON Schemas and the
-          generated payload.{" "}
-          <Link
-            className="text-primary"
-            to="https://github.com/remoteoss/remote-api-demo/blob/master/src/domains/playground/JSONSchemaPlayground.jsx"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            See source on GitHub
-          </Link>
+          generated payload.
         </div>
       </div>
       <div className="grow basis-2/4 flex flex-col items-center">

--- a/src/domains/shared/credentials/CredentialsForm.jsx
+++ b/src/domains/shared/credentials/CredentialsForm.jsx
@@ -13,7 +13,6 @@ import {
   SheetTrigger,
 } from "@/components/ui/Sheet.jsx";
 import { useCredentials } from "@/domains/shared/credentials/useCredentials.js";
-import { Link } from "react-router-dom";
 
 const validationSchema = object({
   clientId: string().required("Client ID is required"),
@@ -23,7 +22,7 @@ const validationSchema = object({
 });
 
 export function CredentialsForm() {
-  const { credentials, setCredentialsForm } = useCredentials();
+  const { credentials, setCredentials } = useCredentials();
 
   const formik = useFormik({
     initialValues: {
@@ -36,7 +35,7 @@ export function CredentialsForm() {
     onSubmit: (values) => {
       // Save form data to localStorage
       localStorage.setItem("credsFormData", JSON.stringify(values));
-      setCredentialsForm(values);
+      setCredentials(values);
     },
   });
 
@@ -51,18 +50,7 @@ export function CredentialsForm() {
         <SheetHeader>
           <SheetTitle>Insert credentials</SheetTitle>
           <SheetDescription>
-            For more information about Remote API credentials, please refer to
-            this
-            <Link
-              className="text-primary ml-1"
-              target="_blank"
-              rel="noopener noreferrer"
-              to={
-                "https://developer.remote.com/docs/authentication-for-partners"
-              }
-            >
-              page.
-            </Link>
+            If you don't know where to find these credentials, please refer to
           </SheetDescription>
         </SheetHeader>
         <div className="p-4 pb-0">
@@ -125,9 +113,8 @@ export function CredentialsForm() {
                   id="gatewayUrl"
                   name="gatewayUrl"
                   type="text"
-                  disabled
                   onChange={formik.handleChange}
-                  defaultValue={formik.values.gatewayUrl}
+                  value={formik.values.gatewayUrl}
                 />
                 {formik.touched.gatewayUrl && formik.errors.gatewayUrl ? (
                   <p className="error">{formik.errors.gatewayUrl}</p>

--- a/src/domains/shared/credentials/useCredentials.js
+++ b/src/domains/shared/credentials/useCredentials.js
@@ -6,22 +6,11 @@ export const useCredentials = create((set) => {
     credentials: {
       clientId: credentials?.clientId || "",
       clientSecret: credentials?.clientSecret || "",
-      gatewayUrl: credentials?.gatewayUrl || "https://gateway.niceremote.com",
+      refreshToken: credentials?.refreshToken || "",
+      gatewayUrl: credentials?.gatewayUrl || "",
     },
-    refreshToken: credentials?.refreshToken || "",
-    partnerAccessToken: "",
-    customerAccessToken: "",
-    setCredentialsForm: (credentials) => {
-      const { refreshToken, ...restCredentials } = credentials;
-      return set((state) => ({
-        ...state,
-        credentials: restCredentials,
-        refreshToken,
-      }));
-    },
-    updateCustomerCredentials: ({
-      access_token: customerAccessToken,
-      refresh_token: refreshToken,
-    }) => set((state) => ({ ...state, customerAccessToken, refreshToken })),
+    partnerAccessToken: null,
+    customerAccessToken: null,
+    setCredentials: (credentials) => set(() => credentials),
   };
 });

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getAccessToken, getClientCredentialsToken } from "@/utils/auth.js";
+import { getAccessToken, getClientCredentialsToken } from "@/utils/auth-utils";
 
 export const partnerApiClient = axios.create({
   headers: {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,11 +1,11 @@
 export function HomePage() {
   return (
     <>
+      <h1 className="h1 self-start m-0">Experience Remote Embedded</h1>
       {/* Static Section for Overview */}
-      <section className="flex flex-col gap-y-6 mx-auto mt-4 max-w-prose ">
-        <h1 className="h1 m-0">Experience Remote Embedded</h1>
+      <section className="flex flex-col gap-y-6 mt-4">
         <div>
-          <h3 className="h3 m-0">About This Tool</h3>
+          <h3 className="h3">About This Tool</h3>
           <p>
             This tool is designed to help partners quickly, easily, and
             efficiently adopt and extend JSON schemas within their own

--- a/src/utils/auth-utils.js
+++ b/src/utils/auth-utils.js
@@ -3,19 +3,17 @@ import axios from "axios";
 
 export const getAccessToken = async () => {
   const credentials = useCredentials.getState().credentials;
-  const refreshToken = useCredentials.getState().refreshToken;
-  const { clientId, clientSecret } = credentials;
+  const { clientId, clientSecret, refreshToken, gatewayUrl } = credentials;
 
-  if (!clientId || !clientSecret || !refreshToken) {
+  if (!clientId || !clientSecret || !refreshToken || !gatewayUrl) {
     const errorMessage = "Error fetching form data: Missing credentials.";
     console.error(errorMessage);
     return null;
   }
 
   const accessToken = useCredentials.getState().customerAccessToken;
-
-  if (accessToken) {
-    return accessToken;
+  if(accessToken) {
+    return accessToken
   }
 
   const encodedCredentials = btoa(`${clientId}:${clientSecret}`);
@@ -34,9 +32,7 @@ export const getAccessToken = async () => {
       }
     );
 
-    useCredentials.setState({
-      customerAccessToken: response.data.access_token,
-    });
+    useCredentials.setState({ customerAccessToken: response.data.access_token });
     return response.data.access_token;
   } catch (error) {
     console.error("Error fetching access token:", error);
@@ -46,18 +42,18 @@ export const getAccessToken = async () => {
 
 export const getClientCredentialsToken = async () => {
   const credentials = useCredentials.getState().credentials;
-
-  const { clientId, clientSecret } = credentials;
-
-  if (!clientId || !clientSecret) {
+  
+  const { clientId, clientSecret, gatewayUrl } = credentials;
+  
+  if (!clientId || !clientSecret || !gatewayUrl) {
     const errorMessage = "Error fetching form data: Missing credentials.";
     console.error(errorMessage);
     return null;
   }
-
+  
   const accessToken = useCredentials.getState().partnerAccessToken;
-  if (accessToken) {
-    return accessToken;
+  if(accessToken) {
+    return accessToken
   }
 
   const encodedCredentials = btoa(`${clientId}:${clientSecret}`);
@@ -74,7 +70,7 @@ export const getClientCredentialsToken = async () => {
         },
       }
     );
-    useCredentials.setState({ partnerAccessToken: response.data.access_token });
+    useCredentials.setState({ partnerAccessToken: response.data.access_token});
     return response.data.access_token;
   } catch (error) {
     console.error("Error fetching access token:", error);


### PR DESCRIPTION
Adds the option to create an employment on behalf of a company created.

Steps:
- Create a company
- At the end of the flow, click on Create new employment button to create an employment of the company's behalf.

- It's still possible to use Create Employment in the top bar but the company associated to the employment in the one provided by the refresh token on the credentials form (on the right side bar)

<img width="1166" alt="image" src="https://github.com/user-attachments/assets/2190e25c-7f29-4b6d-aa01-457d7e6a0ed9">

